### PR TITLE
Resolve a small todo

### DIFF
--- a/src/pablo/pablo_image.jsx
+++ b/src/pablo/pablo_image.jsx
@@ -58,7 +58,7 @@ export default function PabloImage({ src, orientation, alt }) {
   );
 }
 PabloImage.propTypes = {
-  alt: PropTypes.string, // TODO required
+  alt: PropTypes.string.isRequired,
   src: PropTypes.string.isRequired,
   orientation: PropTypes.oneOf(["portrait", "landscape", "square"]).isRequired,
 };


### PR DESCRIPTION
`alt` was already specific everywhere (in `<img alt />`)