### PR TITLE
Increase Netlify timeout

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -16,6 +16,7 @@ jobs:
         id: waitForDeployment
         with:
           site_id: f607824f-3522-4b7e-96ab-75499cc972c4
+          max_timeout: 150
         env:
           NETLIFY_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
 


### PR DESCRIPTION
Netlify is timing out now that we don't have the `yarn install` before it to slow down that GitHub action